### PR TITLE
Filterreset wird nicht mehr für POL angewandt

### DIFF
--- a/Pr0gramm/AppSettings.swift
+++ b/Pr0gramm/AppSettings.swift
@@ -449,7 +449,7 @@ class AppSettings: ObservableObject {
             self.showSFW = true
             self.showNSFW = false
             self.showNSFL = false
-            self.showPOL = false
+            // POL bleibt unverändert, da es bereits SFW ist
             if self.isUserLoggedInForApiFlags {
                 self.showNSFP = true
             }


### PR DESCRIPTION
schließt https://github.com/daranto/Pr0gramm-Client-IOS-MacOS/issues/7 