### PR TITLE
Option das App-Wechsler Thumbnail der App zu verstecken

### DIFF
--- a/Pr0gramm/AppSettings.swift
+++ b/Pr0gramm/AppSettings.swift
@@ -195,6 +195,7 @@ final class AppSettings {
     private static let backgroundFetchIntervalKey = "backgroundFetchInterval_v1"
     private static let forcePhoneLayoutOnPadAndMacKey = "forcePhoneLayoutOnPadAndMac_v1" // Neuer Key
     private static let excludedTagsKey = "excludedTags_v1" // Neue Key für ausgeschlossene Tags
+    private static let disableAppSwitcherPreviewKey = "disableAppSwitcherPreview_v1"
     private var keyValueStoreChangeObserver: NSObjectProtocol?
 
     var isVideoMuted: Bool { didSet { UserDefaults.standard.set(isVideoMuted, forKey: Self.isVideoMutedPreferenceKey) } }
@@ -347,6 +348,16 @@ final class AppSettings {
             Self.logger.info("Background Fetch Interval setting changed to: \(self.backgroundFetchInterval.displayName)")
             if enableBackgroundFetchForNotifications {
                 BackgroundNotificationManager.shared.scheduleAppRefresh()
+            }
+        }
+    }
+
+    // Blendet die Vorschau der App im App-Umschalter (App Switcher) aus
+    var disableAppSwitcherPreview: Bool {
+        didSet {
+            if oldValue != disableAppSwitcherPreview {
+                UserDefaults.standard.set(disableAppSwitcherPreview, forKey: Self.disableAppSwitcherPreviewKey)
+                Self.logger.info("Disable app switcher preview setting changed to: \(self.disableAppSwitcherPreview)")
             }
         }
     }
@@ -546,7 +557,8 @@ final class AppSettings {
         let initialRawFetchInterval = UserDefaults.standard.integer(forKey: Self.backgroundFetchIntervalKey)
         self.backgroundFetchInterval = BackgroundFetchInterval(rawValue: initialRawFetchInterval) ?? .minutes60
         self.forcePhoneLayoutOnPadAndMac = UserDefaults.standard.bool(forKey: Self.forcePhoneLayoutOnPadAndMacKey)
-        
+        self.disableAppSwitcherPreview = UserDefaults.standard.bool(forKey: Self.disableAppSwitcherPreviewKey)
+
         // Load excluded tags - iCloud ist die primäre Datenquelle
         // Wir laden NICHT von UserDefaults beim Start, sondern warten auf iCloud
         self.excludedTags = []
@@ -569,6 +581,7 @@ final class AppSettings {
         Self.logger.info("- enableBackgroundFetchForNotifications: \(self.enableBackgroundFetchForNotifications)")
         Self.logger.info("- backgroundFetchInterval: \(self.backgroundFetchInterval.displayName)")
         Self.logger.info("- forcePhoneLayoutOnPadAndMac: \(self.forcePhoneLayoutOnPadAndMac)")
+        Self.logger.info("- disableAppSwitcherPreview: \(self.disableAppSwitcherPreview)")
 
         if UserDefaults.standard.object(forKey: Self.isVideoMutedPreferenceKey) == nil { UserDefaults.standard.set(self.isVideoMuted, forKey: Self.isVideoMutedPreferenceKey) }
         if UserDefaults.standard.object(forKey: Self.feedTypeKey) == nil { UserDefaults.standard.set(self.feedType.rawValue, forKey: Self.feedTypeKey) }
@@ -589,6 +602,7 @@ final class AppSettings {
         if UserDefaults.standard.object(forKey: Self.enableBackgroundFetchForNotificationsKey) == nil { UserDefaults.standard.set(self.enableBackgroundFetchForNotifications, forKey: Self.enableBackgroundFetchForNotificationsKey) }
         if UserDefaults.standard.object(forKey: Self.backgroundFetchIntervalKey) == nil { UserDefaults.standard.set(self.backgroundFetchInterval.rawValue, forKey: Self.backgroundFetchIntervalKey) }
         if UserDefaults.standard.object(forKey: Self.forcePhoneLayoutOnPadAndMacKey) == nil { UserDefaults.standard.set(self.forcePhoneLayoutOnPadAndMac, forKey: Self.forcePhoneLayoutOnPadAndMacKey) }
+        if UserDefaults.standard.object(forKey: Self.disableAppSwitcherPreviewKey) == nil { UserDefaults.standard.set(self.disableAppSwitcherPreview, forKey: Self.disableAppSwitcherPreviewKey) }
 
 
         updateKingfisherCacheLimit()

--- a/Pr0gramm/Features/Views/Settings/SettingsView.swift
+++ b/Pr0gramm/Features/Views/Settings/SettingsView.swift
@@ -71,13 +71,24 @@ struct SettingsView: View {
                             .font(UIConstants.bodyFont)
                             .tint(settings.accentColorChoice.swiftUIColor)
                     }
+
+                    #if os(iOS)
+                    Toggle("Deaktiviere Thumbnail im App-Umschalter", isOn: $settings.disableAppSwitcherPreview)
+                        .font(UIConstants.bodyFont)
+                        .tint(settings.accentColorChoice.swiftUIColor)
+                    #endif
                 } header: {
                     Text("Darstellung")
                 } footer: {
-                    if UIConstants.isPadOrMac {
-                        Text("Zeigt in der Detailansicht eine zentrierte Einzelspalten-Ansicht anstelle der optimierten Mehrspalten-Ansicht.")
-                            .font(UIConstants.footnoteFont)
+                    VStack(alignment: .leading, spacing: 4) {
+                        if UIConstants.isPadOrMac {
+                            Text("Zeigt in der Detailansicht eine zentrierte Einzelspalten-Ansicht anstelle der optimierten Mehrspalten-Ansicht.")
+                        }
+                        #if os(iOS)
+                        Text("Verbirgt Inhalte hinter einer neutralen Fläche, sobald die App im App-Umschalter oder während des Wechsels in den Hintergrund als Vorschau angezeigt würde.")
+                        #endif
                     }
+                    .font(UIConstants.footnoteFont)
                 }
                 .headerProminence(UIConstants.isRunningOnMac ? .increased : .standard)
 

--- a/Pr0gramm/Pr0grammApp.swift
+++ b/Pr0gramm/Pr0grammApp.swift
@@ -176,8 +176,17 @@ struct AppRootView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
                     .zIndex(10)
             }
+
+            #if os(iOS)
+            if scenePhase != .active {
+                PrivacyCoverView()
+                    .transition(.opacity)
+                    .zIndex(100)
+            }
+            #endif
         }
         .animation(.easeInOut(duration: 0.2), value: networkMonitor.isConnected)
+        .animation(.easeInOut(duration: 0.15), value: scenePhase)
         .accentColor(appSettings.accentColorChoice.swiftUIColor)
         .preferredColorScheme(appSettings.colorSchemeSetting.swiftUIScheme)
         .task {
@@ -189,6 +198,20 @@ struct AppRootView: View {
         }
     }
 }
+
+#if os(iOS)
+private struct PrivacyCoverView: View {
+    var body: some View {
+        Color(.systemBackground)
+            .ignoresSafeArea()
+            .overlay {
+                Image(systemName: "eye.slash.fill")
+                    .font(.system(size: 44))
+                    .foregroundStyle(.secondary)
+            }
+    }
+}
+#endif
 
 struct OfflineConnectionBanner: View {
     var body: some View {

--- a/Pr0gramm/Pr0grammApp.swift
+++ b/Pr0gramm/Pr0grammApp.swift
@@ -178,7 +178,7 @@ struct AppRootView: View {
             }
 
             #if os(iOS)
-            if scenePhase != .active {
+            if appSettings.disableAppSwitcherPreview && scenePhase != .active {
                 PrivacyCoverView()
                     .transition(.opacity)
                     .zIndex(100)


### PR DESCRIPTION
Hey,

würde gerne mehr zu diesem Projekt beitragen und hab ein paar Ideen. Gerne würde ich mit der folgenden anfangen: Wenn die App im App-Wechsler ist oder zur letzten App durch das Wischen der Home-Leiste gewechselt wird, soll es eine Option geben die das Thumbnail verstecken kann. Diese Möglichkeit ist kompatibel sowohl mit dem hellen als auch dem dunklen Farbschemaoptionen.